### PR TITLE
Gum 1682 notify exhibit health

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deeplocal/gumband-public-shared-lib",
-  "version": "0.0.41-0",
+  "version": "0.0.41-alpha-GUM-1682-notify-exhibit-health.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deeplocal/gumband-public-shared-lib",
-      "version": "0.0.41-0",
+      "version": "0.0.41-alpha-GUM-1682-notify-exhibit-health.0",
       "license": "ISC",
       "dependencies": {
         "long": "^5.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deeplocal/gumband-public-shared-lib",
-  "version": "0.0.41-alpha-GUM-1682-notify-exhibit-health.0",
+  "version": "0.0.41-alpha-GUM-1682-notify-exhibit-health.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deeplocal/gumband-public-shared-lib",
-      "version": "0.0.41-alpha-GUM-1682-notify-exhibit-health.0",
+      "version": "0.0.41-alpha-GUM-1682-notify-exhibit-health.1",
       "license": "ISC",
       "dependencies": {
         "long": "^5.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deeplocal/gumband-public-shared-lib",
-  "version": "0.0.40",
+  "version": "0.0.41-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deeplocal/gumband-public-shared-lib",
-      "version": "0.0.40",
+      "version": "0.0.41-0",
       "license": "ISC",
       "dependencies": {
         "long": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deeplocal/gumband-public-shared-lib",
-  "version": "0.0.41-0",
+  "version": "0.0.41-alpha-GUM-1682-notify-exhibit-health.0",
   "description": "A publicly shared library package for the Gumband Ecosystem",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deeplocal/gumband-public-shared-lib",
-  "version": "0.0.41-alpha-GUM-1682-notify-exhibit-health.0",
+  "version": "0.0.41-alpha-GUM-1682-notify-exhibit-health.1",
   "description": "A publicly shared library package for the Gumband Ecosystem",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deeplocal/gumband-public-shared-lib",
-  "version": "0.0.40",
+  "version": "0.0.41-0",
   "description": "A publicly shared library package for the Gumband Ecosystem",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/constants/NotificationTypes.ts
+++ b/src/constants/NotificationTypes.ts
@@ -8,4 +8,4 @@ export const NOTIFICATION_TYPES = {
     notify_scene_changes: 'notify_scene_changes',
     notify_hardware_change: 'notify_hardware_change',
     notify_hardware_notification: 'notify_hardware_notification',
-};
+} as const;


### PR DESCRIPTION
This makes `NOTIFICATION_TYPES` a `const as const` so it can be used to derive literal types from it. I'm 99.9% sure that this is safe—I went through every reference to `NOTIFICATION_TYPES` throughout the services and there's nothing that I see that should be an issue when it's compiled, but I could be missing something. [I've also tested it on this branch in the Exhibit service and there seemed to be no issues](https://github.com/gumbandapp/gumband-exhibit-management-service/tree/hc/const-test), but feel free to give it a spin yourself. We're never attempting to modify the object anywhere, purely just destructuring, so this should be fine.

<img width="686" alt="Screenshot 2025-01-28 at 2 42 54 PM" src="https://github.com/user-attachments/assets/9b617711-3acf-436c-9f9a-42eb44a8781c" />
